### PR TITLE
fix: default undefined environement variables to null

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,9 @@ SECRET_TOKEN: ${ssm:/my-service/prod/SECRET_TOKEN~true}
 Any variable that is not included in the `serverless.env.prod.yml` file will produce a warning and fallback to using `env:`.
 In this case, you will get the following warning:
 
-> Serverless: env-stage-config: WARNING: the MYSQL_PORT variable is not defined in serverless.env.prod.yml, defaulting to ${env:MYSQL_PORT}.
+> Serverless: env-stage-config: WARNING: the MYSQL_PORT variable is not defined in serverless.env.prod.yml, defaulting to ${env:MYSQL_PORT, null}.
+
+If a variable is not defined in the stage environment configuration file, or the environment (`process.env`), it will default to `null`.
 
 ## License
 

--- a/index.js
+++ b/index.js
@@ -42,14 +42,14 @@ class EnvStageConfigServerlessPlugin {
       }
 
       this.serverless.cli.log(
-        `env-stage-config: WARNING: the ${address} variable is not defined in serverless.env.${this.stage}.yml, defaulting to \${env:${address}}.`,
+        `env-stage-config: WARNING: the ${address} variable is not defined in serverless.env.${this.stage}.yml, defaulting to \${env:${address}, null}.`,
         null,
         {color: 'orange'}
       )
     }
 
     return {
-      value: `\${env:${address}}`
+      value: `\${env:${address}, null}`
     }
   }
 }


### PR DESCRIPTION
Support the [NEW_VARIABLES_RESOLVER](https://www.serverless.com/framework/docs/deprecations/#NEW_VARIABLES_RESOLVER) (20210326) that fails when an environment variable is undefined.