### PR TITLE
chore: bump pnpm to 11.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,5 +30,5 @@
   "release": {
     "extends": "@bizon/semantic-release-config"
   },
-  "packageManager": "pnpm@10.27.0+sha512.72d699da16b1179c14ba9e64dc71c9a40988cbdc65c264cb0e489db7de917f20dcf4d64d8723625f2969ba52d4b7e2a1170682d9ac2a5dcaeaab732b7e16f04a"
+  "packageManager": "pnpm@11.10.0+sha512.0b7f8b98060031904c017e3a41eb187a16d40eeb829b95c4f8cb03681761fc4ab53dd219115b9b447f4dce1a05a214764461e7d3703392a9f32f9511ce8c86c8"
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  es5-ext: false
+  unrs-resolver: false
+
+minimumReleaseAge: 0


### PR DESCRIPTION
Bumps the `packageManager` field to pnpm 11.10.0 and adds a `pnpm-workspace.yaml` (build allowlist + `minimumReleaseAge`).